### PR TITLE
Fixed sign error in original quiltshader.glsl, tested working with different Looking Glasses.

### DIFF
--- a/quiltshader.glsl
+++ b/quiltshader.glsl
@@ -12,8 +12,8 @@
 // TODO: Fill these in from HID calibration data.
 const float tilt = -0.12039111681976107; //{tilt};
 const float pitch = 370.66407267416486; //{pitch};
-const float center = 0.5 + 0.13695651292800903; //{center};
-const float subp = 1.0 / (3*2560) * pitch; //{subp};
+const float center = 0.13695651292800903; //{center};
+const float subp = 1.0 / (3*2560); //{subp};
 
 // not all the streams are 5x9 quilts.
 // For instance Baby* is 4x8
@@ -33,7 +33,7 @@ vec2 quilt_map(vec2 pos, float a) {
 vec4 hook() {
   vec4 res;
   float a;
-  a = (HOOKED_pos.x + HOOKED_pos.y*tilt)*pitch - center;
+  a = (HOOKED_pos.x + (1.0 - HOOKED_pos.y)*tilt)*pitch - center;
   res.x = HOOKED_tex(quilt_map(HOOKED_pos, a)).x;
   res.y = HOOKED_tex(quilt_map(HOOKED_pos, a+subp)).y;
   res.z = HOOKED_tex(quilt_map(HOOKED_pos, a+2*subp)).z;

--- a/shadergen.py
+++ b/shadergen.py
@@ -1,0 +1,60 @@
+import math
+import sys
+import json
+
+# Call with the following arguments:
+# python shadergen.py [views_x] [views_y] [calibration.json]
+
+# Generates glsl shader file based on visual calibration file
+calib = json.load(open(sys.argv[3]))
+
+def v(n):
+    return calib[n]['value']
+
+views_x = sys.argv[1] 
+views_y = sys.argv[2]
+# Panel resolution
+size = (int(v('screenW')), int(v('screenH')))
+# Physical image width
+screenInches = size[0]/v('DPI')
+pitch = v('pitch') * screenInches * math.cos(math.atan(1.0/v('slope')))
+tilt = size[1]/(size[0]*v('slope'))
+subp = 1.0 / (3*size[0]) * pitch
+center = v('center')
+
+shader_text = '''
+//!HOOK MAINPRESUB
+//!DESC Looking Glass Quilt renderer
+//!BIND HOOKED
+//!WIDTH ''' + str(size[0]) + '''
+//!HEIGHT ''' + str(size[1]) + '''
+
+const float pitch = '''+str(pitch)+''';
+const float center = '''+str(center)+''';
+const float tilt = '''+str(tilt)+''';
+const float subp = '''+str(subp)+''';
+
+const vec2 tiles = vec2('''+str(float(views_x))+''','''+str(float(views_y))+''');
+
+vec2 quilt_map(vec2 pos, float a) {
+  // Y major positive direction, X minor negative direction
+  vec2 tile = vec2(tiles.x-1,0), dir=vec2(-1,1);
+  a = fract(a)*tiles.y;
+  tile.y += dir.y*floor(a);
+  a = fract(a)*tiles.x;
+  tile.x += dir.x*floor(a);
+  return (tile+pos)/tiles;
+}
+
+vec4 hook() {
+  vec4 res;
+  float a;
+  a = (HOOKED_pos.x + (1.0 - HOOKED_pos.y)*tilt)*pitch - center;
+  res.x = HOOKED_tex(quilt_map(HOOKED_pos, a)).x;
+  res.y = HOOKED_tex(quilt_map(HOOKED_pos, a+subp)).y;
+  res.z = HOOKED_tex(quilt_map(HOOKED_pos, a+2*subp)).z;
+  res.w = 1.0;
+  return res;
+}
+'''
+print(shader_text)


### PR DESCRIPTION
Also - added `shadergen.py`, which will generate a new quiltshader.glsl given an input calibration JSON and a view count.

Usage:
`python shadergen.py [views_x] [views_y] [calibration.json] > new_shader.glsl`